### PR TITLE
feat: add adventurer track

### DIFF
--- a/Constants.lua
+++ b/Constants.lua
@@ -294,6 +294,7 @@ addon.TEXT_POSITIONS = {
 
 -- Upgrade track definitions based on crest data
 addon.UPGRADE_TRACKS = (function()
+    local weathered = addon.CREST_BASE["WEATHERED"]
     local tracks = {
         EXPLORER = {
             color = "|cFFffffff",
@@ -311,6 +312,25 @@ addon.UPGRADE_TRACKS = (function()
                     crest = nil,
                     shortname = "Explorer",
                     levels = 0
+                }
+            }
+        },
+        ADVENTURER = {
+            color = "|cFFffffff",
+            crest = nil,
+            shortname = "Adventurer",
+            finalCrest = weathered.baseName .. " " .. weathered.shortCode,
+            upgradeLevels = 8,
+            splitUpgrade = {
+                firstTier = {
+                    crest = nil,
+                    shortname = "Adventurer",
+                    levels = 4
+                },
+                secondTier = {
+                    crest = weathered.baseName .. " " .. weathered.shortCode,
+                    shortname = weathered.baseName,
+                    levels = 4
                 }
             }
         }


### PR DESCRIPTION
Adventurer track items were not handled before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Adventurer upgrade track with defined progression levels and a two-tier split upgrade culminating in a Weathered crest.
  * The upgrade interface now displays the Adventurer track alongside the existing Explorer track for easier selection and tracking.
  * Clarifies end-tier outcomes and split upgrade paths for Adventurer, improving visibility into upgrade progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->